### PR TITLE
Modify: netMap_hor.py, Add: netmap_template.py

### DIFF
--- a/laygo2_test/netMap_hor.py
+++ b/laygo2_test/netMap_hor.py
@@ -1,5 +1,5 @@
 #rows 리스트에서 해당 row에 맞는 요소의 index 반환
-def searchRow(rows, row_num):
+def search_row(rows, row_num):
     start=0
     end=len(rows)-1
     while start <= end:
@@ -14,7 +14,7 @@ def searchRow(rows, row_num):
 
 
 #newMetal.xy1[0]을 기준으로 list의 제 위치에 찾기/via가 들어갈 metal 찾는데도 이용. 기준 좌표가 같은 요소가 있는 경우 반환값은 해당 요소의 인덱스+1이 됨
-def searchMetalIndex(row, obj_x1):
+def search_metal_index(row, obj_x1):
     start = 0
     end = len(row.metal_list)-1
 
@@ -39,7 +39,7 @@ def searchMetalIndex(row, obj_x1):
 
 
 #이진 탐색 비슷하게 해서 new_row_num의 숫자가 들어갈 인덱스를 찾아 반환한다.
-def getRowIndex(rows, new_row_num):       
+def get_row_index(rows, new_row_num):       
     start = 0
     end = len(rows)-1
     if len(rows) == 0:
@@ -61,26 +61,36 @@ def getRowIndex(rows, new_row_num):
     else:
         return end 
 
-
-def insertVia(via_mn, layer1, layer2):
-    row_index = searchRow(layer1.rows, via_mn[1])
-    if row_index == None:
-        print("Error: there is no metal on the via's coordinate")
-    metal_index = searchMetalIndex(layer1.rows[row_index], via_mn[0])-1
-    layer1_metal = layer1.rows[row_index].metal_list[metal_index]
-    if layer1_metal.mn[1][0] < via_mn[0]:
-        print("Error: there is no metal on the via's coordinate")
+#via의 좌표, 세로 layer(layer1), 가로 layer(layer2)를 입력받음.
+def insert_via(via_mn, layer1, layer2):
+    col_index = search_col(layer1.cols, via_mn[1])
+    if col_index is None:
+        print("Error: no metal on via")
+        return
+    metal_index = search_metal_index(layer1.cols[col_index], via_mn[0])-1
+    if metal_index == -1:
+        print("Error: no metal on via")
+        return
+    layer1_metal = layer1.cols[col_index].metal_list[metal_index]
+    if layer1_metal.mn[1][1] > via_mn[0]:           #추후 netMap_ver의 구현에 따라 부등호 방향 달라질 수도 있음
+        print("Error: no metal on via")
+        return
     
-    row_index = searchRow(layer2.rows, via_mn[1])
-    if row_index == None:
-        print("Error: there is no metal on the via's coordinate")
-    metal_index = searchMetalIndex(layer2.rows[row_index], via_mn[0])-1
+    row_index = search_row(layer2.rows, via_mn[1])
+    if row_index is None:
+        print("Error: no metal on via")
+        return
+    metal_index = search_metal_index(layer2.rows[row_index], via_mn[0])-1
+    if metal_index == -1:
+        print("Error: no metal on via")
+        return
     layer2_metal = layer2.rows[row_index].metal_list[metal_index]
     if layer2_metal.mn[1][0] < via_mn[0]:
-        print("Error: there is no metal on the via's coordinate")
+        print("Error: no metal on via")
+        return
     
-    layer1_metal.via_list.append(layer2_metal)
-    layer2_metal.via_list.append(layer1_metal)
+    layer1_metal.via_list.append([layer2_metal, layer2, via_mn])
+    layer2_metal.via_list.append([layer1_metal, layer1, via_mn])
 
    
 class rowNode:
@@ -93,9 +103,10 @@ class metalNode:
     def __init__(self, mn, pin=None):
         self.mn = mn
         self.net_name = list()
-        self.metal = list()
+        self.metal_seg = list()
         self.via_list = list()
         self.pin = pin
+        self.color = None
         
 
 class netMap_hor:
@@ -104,48 +115,9 @@ class netMap_hor:
         
     #정렬된 row와 새로 깔 metal 받아서 merge
     def merge(self, new_metal, row_index):
-        new_metal_index = searchMetalIndex(self.rows[row_index], new_metal.mn[0][0])
+        new_metal_index = search_metal_index(self.rows[row_index], new_metal.mn[0][0])
 
-        if new_metal_index == 0:         #row의 맨 앞에 새로운 metal을 삽입하는 경우
-            if new_metal_index == len(self.rows[row_index].metal_list):
-                self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
-            else:        #뒤쪽 원소들과 겹치는지 확인해 겹치면 merge
-                while new_metal_index<len(self.rows[row_index].metal_list):
-                    if new_metal.mn[1][0]<self.rows[row_index].metal_list[new_metal_index].mn[0][0]:
-                        break
-                    else:
-                        metal_next = self.rows[row_index].metal_list.pop(new_metal_index)
-                        new_name = new_metal.net_name
-                        for name in metal_next.net_name:
-                            if name not in new_name:
-                                new_name.append(name)
-
-                        new_metals = new_metal.metal
-                        new_metals.extend(metal_next.metal)
-
-                        if new_metal.pin is None and metal_next.pin is not None:
-                            new_pin = metal_next.pin
-                        elif new_metal.pin is not None and metal_next.pin is None:
-                            new_pin = new_metal.pin
-                        elif new_metal.pin is not None and metal_next.pin is not None:
-                            print("Warning: pin name overlap")
-                            new_pin = new_metal.pin+'/'+metal_next.pin
-                        else:
-                            new_pin = None
-
-                        #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
-                        if new_metal.mn[1][0]<metal_next.mn[1][0]:          
-                            new_metal = metalNode([new_metal.mn[0], metal_next.mn[1]], pin=new_pin)
-                            new_metal.net_name.extend(new_name)
-                            new_metal.metal.extend(new_metals)
-                        else:
-                            new_metal = metalNode([new_metal.mn[0], new_metal.mn[1]], pin=new_pin)
-                            new_metal.net_name.extend(new_name)
-                            new_metal.metal.extend(new_metals)
-            
-                self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
-
-        else:
+        if new_metal_index > 0:         #row의 맨 앞이 아닌 곳에 새로운 metal을 삽입하는 경우
             #먼저 바로 앞 metal과 겹치는지를 확인해 처리한다.=>겹치더라도 하나의 metal과만 겹침
             if new_metal.mn[0][0]<=self.rows[row_index].metal_list[new_metal_index-1].mn[1][0]:      #앞 metal이랑 겹치면
                 metal_prev = self.rows[row_index].metal_list.pop(new_metal_index-1)
@@ -154,8 +126,7 @@ class netMap_hor:
                     if name not in new_name:
                         new_name.append(name)
 
-                new_metals = new_metal.metal
-                new_metals.extend(metal_prev.metal)
+                new_metal.metal_seg.extend(metal_prev.metal_seg)
 
                 if new_metal.pin is None and metal_prev.pin is not None:
                     new_pin = metal_prev.pin
@@ -173,66 +144,69 @@ class netMap_hor:
                 else:
                     xy2 = metal_prev.mn[1]
                 
-                new_metal = metalNode([metal_prev.mn[0], xy2], pin=new_pin)
-                new_metal.net_name.extend(new_name)
-                new_metal.metal.extend(new_metals)
+                new_metal_tmp = metalNode([metal_prev.mn[0], xy2], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+                new_metal = new_metal_tmp
                 new_metal_index=new_metal_index-1
 
-            #뒤쪽 metal들과 겹치는지 확인해 처리
-            while new_metal_index<len(self.rows[row_index].metal_list):
-                if new_metal.mn[1][0]<self.rows[row_index].metal_list[new_metal_index].mn[0][0]:
-                    break
-                else:
-                    metal_next = self.rows[row_index].metal_list.pop(new_metal_index)
-                    new_name = new_metal.net_name
-                    for name in metal_next.net_name:
-                        if name not in new_name:
-                            new_name.append(name)
+        #뒤쪽 metal들과 겹치는지 확인해 처리
+        while new_metal_index<len(self.rows[row_index].metal_list):
+            if new_metal.mn[1][0]<self.rows[row_index].metal_list[new_metal_index].mn[0][0]:
+                break
+            
+            metal_next = self.rows[row_index].metal_list.pop(new_metal_index)
+            new_name = new_metal.net_name
+            for name in metal_next.net_name:
+                if name not in new_name:
+                    new_name.append(name)
 
-                    new_metals = new_metal.metal
-                    new_metals.extend(metal_next.metal)
+            new_metal.metal_seg.extend(metal_next.metal_seg)
 
-                    if new_metal.pin is None and metal_next.pin is not None:
-                            new_pin = metal_next.pin
-                    elif new_metal.pin is not None and metal_next.pin is None:
-                        new_pin = new_metal.pin
-                    elif new_metal.pin is not None and metal_next.pin is not None:
-                        print("Warning: pin name overlap")
-                        new_pin = new_metal.pin+'/'+metal_next.pin
-                    else:
-                        new_pin = None
+            if new_metal.pin is None and metal_next.pin is not None:
+                new_pin = metal_next.pin
+            elif new_metal.pin is not None and metal_next.pin is None:
+                new_pin = new_metal.pin
+            elif new_metal.pin is not None and metal_next.pin is not None:
+                print("Warning: pin name overlap")
+                new_pin = new_metal.pin+'/'+metal_next.pin
+            else:
+                new_pin = None
 
-                    if new_metal.mn[1][0] < metal_next.mn[1][0]:          #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
-                        new_metal = metalNode([new_metal.mn[0], metal_next.mn[1]], pin=new_pin)
-                        new_metal.net_name.extend(new_name)
-                        new_metal.metal.extend(new_metals)
-                    else:
-                        new_metal = metalNode([new_metal.mn[0], new_metal.mn[1]], pin=new_pin)
-                        new_metal.netName.extend(new_name)
-                        new_metal.metal.extend(new_metals)
+            if new_metal.mn[1][0] < metal_next.mn[1][0]:          #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
+                new_metal_tmp = metalNode([new_metal.mn[0], metal_next.mn[1]], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+            else:
+                new_metal_tmp = metalNode([new_metal.mn[0], new_metal.mn[1]], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+            new_metal = new_metal_tmp
         
-            self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
+        self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
         
-    def insertMetal(self, mn, net_name=None):
+    #구버전 insert_metal
+    '''def insert_metal(self, mn, net_name=None):
         if mn[0][1] != mn[1][1]:
             print('Not horizontal')
         else:
-            row_index = searchRow(self.rows, mn[0][1])
+            row_index = search_row(self.rows, mn[0][1])
             if row_index is None:
                 #self.rows에 rowNode(mn[0][1])를 순서에 맞춰 삽입
-                new_row_index = getRowIndex(self.rows, mn[0][1])
+                new_row_index = get_row_index(self.rows, mn[0][1])
                 self.rows.insert(new_row_index, rowNode(mn[0][1]))
                 new_node = metalNode(mn)
                 new_node.net_name.append(net_name)
-                new_node.metal.append(new_node)           
-                self.merge(new_node, new_row_index)
+                new_node.metal_seg.append(new_node)
+                self.rows.[new_row_index].metal_list.append(new_node)
             else:
                 new_node = metalNode(mn)
                 new_node.net_name.append(net_name)
-                new_node.metal.append(new_node)
-                self.merge(new_node, row_index)
+                new_node.metal_seg.append(new_node)
+                self.merge(new_node, row_index)'''
                 
-    def insertPin(self, mn, pin_name=None, net_name=None):
+    #신버전 insert_metal
+    def insert_metal(self, mn, net_name=None):
         if mn[0][0] < mn[1][0]:
             x1=mn[0][0]
             x2=mn[1][0]
@@ -248,17 +222,32 @@ class netMap_hor:
             y2=mn[0][1]
 
         for i in range (y1, y2+1):
-            row_index = searchRow(self.rows, i)
+            row_index = search_row(self.rows, i)
             if row_index is None:
                 #self.rows에 rowNode(i)를 순서에 맞춰 삽입
-                new_row_index = getRowIndex(self.rows, i)
+                new_row_index = get_row_index(self.rows, i)
                 self.rows.insert(new_row_index, rowNode(i))
-                new_node = metalNode([[x1, i], [x2, i]], pin=pin_name)
+                new_node = metalNode([[x1, i], [x2, i]])
                 new_node.net_name.append(net_name)
-                new_node.metal.append(new_node)
-                self.merge(new_node, new_row_index)
+                new_node.metal_seg.append(new_node)
+                self.rows[new_row_index].metal_list.append(new_node)
             else:
-                new_node = metalNode([[x1, i], [x2, i]], pin=pin_name)
+                new_node = metalNode([[x1, i], [x2, i]])
                 new_node.net_name.append(net_name)
-                new_node.metal.append(new_node)
-                self.merge(new_node, row_index)    
+                new_node.metal_seg.append(new_node)
+                self.merge(new_node, row_index)
+
+    def insert_pin(self, pin):            #pin은 pin의 좌표를 표시하는 mn과 이름을 표시하는 name 변수를 가지고 있다고 생각하고 작성
+        mn = pin.mn
+        pin_name = pin.name
+        row_index = search_row(self.rows, mn[1])
+        if row_index is None:
+            print("Error: no metal on pin")
+            return
+        metal_index = search_metal_index(self.rows[row_index], mn[0])-1
+        metal = self.rows[row_index].metal_list[metal_index]
+        if metal.mn[1][0] < mn[0]:
+            print("Error: no metal on pin")
+            return
+        metal.pin = pin_name
+        return metal

--- a/laygo2_test/netMap_hor.py
+++ b/laygo2_test/netMap_hor.py
@@ -1,87 +1,101 @@
-#2022-08-03 기준: pin 객체 관련 추가, error 출력 관련 추가 필요.
-#grid.route, grid.route_via_track등의 함수에서 metal을 깔고 via를 뚫을 때마다 netMap의 Add 함수 호출.
-
 #rows 리스트에서 해당 row에 맞는 요소의 index 반환
-def searchRow(rows, rowNum):
+def searchRow(rows, row_num):
     start=0
     end=len(rows)-1
     while start <= end:
         mid = (start+end)//2
-        if rows[mid].rowNum == rowNum:
+        if rows[mid].row_num == row_num:
             return mid
-        elif rows[mid].rowNum > rowNum:
+        elif rows[mid].row_num > row_num:
             end = mid-1
         else:
-            start = mid + 1
+            start = mid+1
     return None
 
-#newMetal.xy1[0]을 기준으로 list의 제 위치에 찾기/via가 들어갈 metal 찾는데도 이용. 기준 좌표가 같은 요소가 있는 경우 반환값은 해당 요소의 인덱스+1이 됨
-def searchMetalIndex(row, newObj_x1):
-    start = 0
-    end = len(row.metalList)-1
 
-    if len(row.metalList) == 0:
+#newMetal.xy1[0]을 기준으로 list의 제 위치에 찾기/via가 들어갈 metal 찾는데도 이용. 기준 좌표가 같은 요소가 있는 경우 반환값은 해당 요소의 인덱스+1이 됨
+def searchMetalIndex(row, obj_x1):
+    start = 0
+    end = len(row.metal_list)-1
+
+    if len(row.metal_list) == 0:
         return 0
     
-    while start + 1 < end:
+    while start+1 < end:
         mid = (start+end)//2
-        if row.metalList[mid].xy1[0] > newObj_x1:       #newMetal이 더 앞일때
+        if row.metal_list[mid].mn[0][0] > obj_x1:       
             end = mid
-        elif row.metalList[mid].xy1[0] < newObj_x1:      #newMetal이 더 뒤일때
+        elif row.metal_list[mid].mn[0][0] < obj_x1:      
             start = mid
         else:
             return mid+1
 
-    if row.metalList[start].xy1[0] > newObj_x1:       #newMetal이 더 앞일때
+    if row.metal_list[start].mn[0][0] > obj_x1:       
         return start
-    elif row.metalList[end].xy1[0] <= newObj_x1:      #newMetal이 더 뒤일때
-        return end + 1
+    elif row.metal_list[end].mn[0][0] <= obj_x1:      
+        return end+1
     else:
         return end
 
 
-
-def getRowIndex(rows, newRowNum):       #이진 탐색 비슷하게 해서 newRowNum의 숫자가 들어갈 인덱스를 찾아 반환한다.
+#이진 탐색 비슷하게 해서 new_row_num의 숫자가 들어갈 인덱스를 찾아 반환한다.
+def getRowIndex(rows, new_row_num):       
     start = 0
     end = len(rows)-1
     if len(rows) == 0:
         return 0
     
-    while start + 1 < end:
+    while start+1 < end:
         mid = (start+end)//2
-        if rows[mid].rowNum > newRowNum:
+        if rows[mid].row_num > new_row_num:
             end = mid
-        elif rows[mid].rowNum < newRowNum:
+        elif rows[mid].row_num < new_row_num:
             start = mid
         else:
             return mid
         
-    if rows[start].rowNum > newRowNum:
+    if rows[start].row_num > new_row_num:
         return start
-    elif rows[end].rowNum < newRowNum:
-        return end + 1
+    elif rows[end].row_num < new_row_num:
+        return end+1
     else:
         return end 
 
-def merge_via(vias1, vias2):
-    viaList = vias1
-    for via in vias2:
-        if via not in viaList:
-            viaList.append(via)
-    return viaList
-    
 
+def insertVia(via_mn, layer1, layer2):
+    row_index = searchRow(layer1.rows, via_mn[1])
+    if row_index == None:
+        print("Error: there is no metal on the via's coordinate")
+    metal_index = searchMetalIndex(layer1.rows[row_index], via_mn[0])-1
+    layer1_metal = layer1.rows[row_index].metal_list[metal_index]
+    if layer1_metal.mn[1][0] < via_mn[0]:
+        print("Error: there is no metal on the via's coordinate")
+    
+    row_index = searchRow(layer2.rows, via_mn[1])
+    if row_index == None:
+        print("Error: there is no metal on the via's coordinate")
+    metal_index = searchMetalIndex(layer2.rows[row_index], via_mn[0])-1
+    layer2_metal = layer2.rows[row_index].metal_list[metal_index]
+    if layer2_metal.mn[1][0] < via_mn[0]:
+        print("Error: there is no metal on the via's coordinate")
+    
+    layer1_metal.via_list.append(layer2_metal)
+    layer2_metal.via_list.append(layer1_metal)
+
+   
 class rowNode:
-    def __init__(self, rowNum):
-        self.rowNum = rowNum
-        self.metalList = list()
-        
+    def __init__(self, row_num):
+        self.row_num = row_num
+        self.metal_list = list()
+
+
 class metalNode:
-    def __init__(self, point1, point2, netName=None):
-        self.xy1 = point1
-        self.xy2 = point2
-        self.netName = netName
-        self.vias = list()
+    def __init__(self, mn, pin=None):
+        self.mn = mn
+        self.net_name = list()
+        self.metal = list()
+        self.via_list = list()
+        self.pin = pin
         
 
 class netMap_hor:
@@ -89,116 +103,136 @@ class netMap_hor:
         self.rows = list()
         
     #정렬된 row와 새로 깔 metal 받아서 merge
-    def merge(self, newMetal, rowIndex):
-        newMetal_index = searchMetalIndex(self.rows[rowIndex], newMetal.xy1[0])
+    def merge(self, new_metal, row_index):
+        new_metal_index = searchMetalIndex(self.rows[row_index], new_metal.mn[0][0])
 
-        if newMetal_index == 0:         #row의 맨 앞에 새로운 metal을 삽입하는 경우
-            if newMetal_index == len(self.rows[rowIndex].metalList):
-                self.rows[rowIndex].metalList.insert(newMetal_index, newMetal)
+        if new_metal_index == 0:         #row의 맨 앞에 새로운 metal을 삽입하는 경우
+            if new_metal_index == len(self.rows[row_index].metal_list):
+                self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
             else:        #뒤쪽 원소들과 겹치는지 확인해 겹치면 merge
-                while newMetal_index<len(self.rows[rowIndex].metalList):
-                    if newMetal.xy2[0]<self.rows[rowIndex].metalList[newMetal_index].xy1[0]:
+                while new_metal_index<len(self.rows[row_index].metal_list):
+                    if new_metal.mn[1][0]<self.rows[row_index].metal_list[new_metal_index].mn[0][0]:
                         break
                     else:
-                        metal_next = self.rows[rowIndex].metalList.pop(newMetal_index)
-                        newName = newMetal.netName
-                        if newMetal.netName != metal_next.netName:
-                            print("Error: overlap of metals that have different netname.")
-                            newName = newMetal.netName + "/" + metal_next.netName
+                        metal_next = self.rows[row_index].metal_list.pop(new_metal_index)
+                        new_name = new_metal.net_name
+                        for name in metal_next.net_name:
+                            if name not in new_name:
+                                new_name.append(name)
 
-                        
+                        new_metals = new_metal.metal
+                        new_metals.extend(metal_next.metal)
 
-                        viaList = merge_via(newMetal.vias, metal_next.vias)
-
-                        if newMetal.xy2[0]<metal_next.xy2[0]:          #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
-                            newMetal = metalNode(newMetal.xy1, metal_next.xy2, newName)
-                            for via in viaList:
-                                newMetal.vias.append(via)
+                        if new_metal.pin is None and metal_next.pin is not None:
+                            new_pin = metal_next.pin
+                        elif new_metal.pin is not None and metal_next.pin is None:
+                            new_pin = new_metal.pin
+                        elif new_metal.pin is not None and metal_next.pin is not None:
+                            print("Warning: pin name overlap")
+                            new_pin = new_metal.pin+'/'+metal_next.pin
                         else:
-                            newMetal = metalNode(newMetal.xy1, newMetal.xy2, newName)
-                            for via in viaList:
-                                newMetal.vias.append(via)
+                            new_pin = None
+
+                        #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
+                        if new_metal.mn[1][0]<metal_next.mn[1][0]:          
+                            new_metal = metalNode([new_metal.mn[0], metal_next.mn[1]], pin=new_pin)
+                            new_metal.net_name.extend(new_name)
+                            new_metal.metal.extend(new_metals)
+                        else:
+                            new_metal = metalNode([new_metal.mn[0], new_metal.mn[1]], pin=new_pin)
+                            new_metal.net_name.extend(new_name)
+                            new_metal.metal.extend(new_metals)
             
-                self.rows[rowIndex].metalList.insert(newMetal_index, newMetal)
+                self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
 
         else:
             #먼저 바로 앞 metal과 겹치는지를 확인해 처리한다.=>겹치더라도 하나의 metal과만 겹침
-            if newMetal.xy1[0]<=self.rows[rowIndex].metalList[newMetal_index-1].xy2[0]:      #앞 metal이랑 겹치면
-                metal_prev = self.rows[rowIndex].metalList.pop(newMetal_index-1)
-                newName = newMetal.netName
-                if newMetal.netName != metal_prev.netName:
-                    print("Error: overlap of metals that have different netname")
-                    newName = newMetal.netName + "/" + metal_prev.netName
+            if new_metal.mn[0][0]<=self.rows[row_index].metal_list[new_metal_index-1].mn[1][0]:      #앞 metal이랑 겹치면
+                metal_prev = self.rows[row_index].metal_list.pop(new_metal_index-1)
+                new_name = new_metal.net_name
+                for name in metal_prev.net_name:
+                    if name not in new_name:
+                        new_name.append(name)
 
-                
-                viaList = merge_via(newMetal.vias, metal_prev.vias)
-                
-                if metal_prev.xy2[0]<newMetal.xy2[0]:               #metal_prev 끝이 newMetal 끝보다 앞에 있을 경우
-                    xy2 = newMetal.xy2
+                new_metals = new_metal.metal
+                new_metals.extend(metal_prev.metal)
+
+                if new_metal.pin is None and metal_prev.pin is not None:
+                    new_pin = metal_prev.pin
+                elif new_metal.pin is not None and metal_prev.pin is None:
+                    new_pin = new_metal.pin
+                elif new_metal.pin is not None and metal_prev.pin is not None:
+                    print("Warning: pin name overlap")
+                    new_pin = new_metal.pin+'/'+metal_prev.pin
                 else:
-                    xy2 = metal_prev.xy2
-                newMetal = metalNode(metal_prev.xy1, xy2, newName)
-                for via in viaList:
-                    newMetal.vias.append(via)
-                newMetal_index=newMetal_index-1
+                    new_pin = None
+                
+                #metal_prev 끝이 newMetal 끝보다 앞에 있을 경우
+                if metal_prev.mn[1][0] < new_metal.mn[1][0]:               
+                    xy2 = new_metal.mn[1]
+                else:
+                    xy2 = metal_prev.mn[1]
+                
+                new_metal = metalNode([metal_prev.mn[0], xy2], pin=new_pin)
+                new_metal.net_name.extend(new_name)
+                new_metal.metal.extend(new_metals)
+                new_metal_index=new_metal_index-1
 
             #뒤쪽 metal들과 겹치는지 확인해 처리
-            while newMetal_index<len(self.rows[rowIndex].metalList):
-                if newMetal.xy2[0]<self.rows[rowIndex].metalList[newMetal_index].xy1[0]:
+            while new_metal_index<len(self.rows[row_index].metal_list):
+                if new_metal.mn[1][0]<self.rows[row_index].metal_list[new_metal_index].mn[0][0]:
                     break
                 else:
-                    metal_next = self.rows[rowIndex].metalList.pop(newMetal_index)
-                    newName = newMetal.netName
-                    if newMetal.netName != metal_next.netName:
-                        print("Error: overlap of metals that have different netname.")
-                        newName = newMetal.netName + "/" + metal_next.netName
+                    metal_next = self.rows[row_index].metal_list.pop(new_metal_index)
+                    new_name = new_metal.net_name
+                    for name in metal_next.net_name:
+                        if name not in new_name:
+                            new_name.append(name)
 
-                    viaList = merge_via(newMetal.vias, metal_next.vias)
+                    new_metals = new_metal.metal
+                    new_metals.extend(metal_next.metal)
 
-                    if newMetal.xy2[0]<metal_next.xy2[0]:          #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
-                        newMetal = metalNode(newMetal.xy1, metal_next.xy2, newName)
-                        for via in viaList:
-                            newMetal.vias.append(via)
+                    if new_metal.pin is None and metal_next.pin is not None:
+                            new_pin = metal_next.pin
+                    elif new_metal.pin is not None and metal_next.pin is None:
+                        new_pin = new_metal.pin
+                    elif new_metal.pin is not None and metal_next.pin is not None:
+                        print("Warning: pin name overlap")
+                        new_pin = new_metal.pin+'/'+metal_next.pin
                     else:
-                        newMetal = metalNode(newMetal.xy1, newMetal.xy2, newName)
-                        for via in viaList:
-                             newMetal.vias.append(via)
-        
-            self.rows[rowIndex].metalList.insert(newMetal_index, newMetal)
+                        new_pin = None
 
+                    if new_metal.mn[1][0] < metal_next.mn[1][0]:          #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
+                        new_metal = metalNode([new_metal.mn[0], metal_next.mn[1]], pin=new_pin)
+                        new_metal.net_name.extend(new_name)
+                        new_metal.metal.extend(new_metals)
+                    else:
+                        new_metal = metalNode([new_metal.mn[0], new_metal.mn[1]], pin=new_pin)
+                        new_metal.netName.extend(new_name)
+                        new_metal.metal.extend(new_metals)
         
-            
-    #Warning: deprecated function   
-    def insertMetal(self, mn, via1, via2, netName=None):        #(grid.route 기준)__mn, netName, via_tag[i], [i+1] 넘겨주면 됨
-        #에러발생
-        point1=mn[0]
-        point2=mn[1]
-        if point1[1] != point2[1]:
+            self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
+        
+    def insertMetal(self, mn, net_name=None):
+        if mn[0][1] != mn[1][1]:
             print('Not horizontal')
         else:
-            rowIndex = searchRow(self.rows, point1[1])
-            if rowIndex is None:
-                #self.rows에 rowNode(point1[1])를 순서에 맞춰 삽입
-                newRowIndex = getRowIndex(self.rows, point1[1])
-                self.rows.insert(newRowIndex, rowNode(point1[1]))
-                
-                vias=list()
-                if via1 == True:
-                    vias.append(point1)
-                if via2 == True:
-                    vias.append(point2)
-                
-                self.merge(metalNode(point1, point2, vias, netName), newRowIndex)
+            row_index = searchRow(self.rows, mn[0][1])
+            if row_index is None:
+                #self.rows에 rowNode(mn[0][1])를 순서에 맞춰 삽입
+                new_row_index = getRowIndex(self.rows, mn[0][1])
+                self.rows.insert(new_row_index, rowNode(mn[0][1]))
+                new_node = metalNode(mn)
+                new_node.net_name.append(net_name)
+                new_node.metal.append(new_node)           
+                self.merge(new_node, new_row_index)
             else:
-                vias=list()
-                if via1 == True:
-                    vias.append(point1)
-                if via2 == True:
-                    vias.append(point2)
-                self.merge(metalNode(point1, point2, vias, netName), rowIndex)
+                new_node = metalNode(mn)
+                new_node.net_name.append(net_name)
+                new_node.metal.append(new_node)
+                self.merge(new_node, row_index)
                 
-
-    def insertPin(self, mn, netName=None):
+    def insertPin(self, mn, pin_name=None, net_name=None):
         if mn[0][0] < mn[1][0]:
             x1=mn[0][0]
             x2=mn[1][0]
@@ -214,29 +248,17 @@ class netMap_hor:
             y2=mn[0][1]
 
         for i in range (y1, y2+1):
-            rowIndex = searchRow(self.rows, i)
-            if rowIndex is None:
+            row_index = searchRow(self.rows, i)
+            if row_index is None:
                 #self.rows에 rowNode(i)를 순서에 맞춰 삽입
-                newRowIndex = getRowIndex(self.rows, i)
-                self.rows.insert(newRowIndex, rowNode(i))
-                self.merge(metalNode([x1, i], [x2, i], netName), newRowIndex)
+                new_row_index = getRowIndex(self.rows, i)
+                self.rows.insert(new_row_index, rowNode(i))
+                new_node = metalNode([[x1, i], [x2, i]], pin=pin_name)
+                new_node.net_name.append(net_name)
+                new_node.metal.append(new_node)
+                self.merge(new_node, new_row_index)
             else:
-                self.merge(metalNode([x1, i], [x2, i], netName), rowIndex)
-    
-    #list로 via들의 좌표를 입력받는다.
-    def insertVia(self, vias):
-        for via in vias:
-            rowIndex = searchRow(self.rows, via[1])
-            if rowIndex == None:
-                print("Error: there is no metal on the via's coordinate")
-            metalIndex = searchMetalIndex(self.rows[rowIndex], via[0])-1
-            metalOfVia = self.rows[rowIndex].metalList[metalIndex]
-            if metalOfVia.xy2[0] < via[0]:
-                print("Error: there is no metal on the via's coordinate")
-            else:
-                metalOfVia.vias.append(via)
-
-
-
-            
-    
+                new_node = metalNode([[x1, i], [x2, i]], pin=pin_name)
+                new_node.net_name.append(net_name)
+                new_node.metal.append(new_node)
+                self.merge(new_node, row_index)    

--- a/laygo2_test/netmap_template.py
+++ b/laygo2_test/netmap_template.py
@@ -1,0 +1,444 @@
+class rowNode:
+    def __init__(self, row_num):
+        self.row_num = row_num
+        self.metal_list = list()
+
+class colNode:
+    def __init__(self, col_num):
+        self.col_num = col_num
+        self.metal_list = list()
+
+class metalNode:
+    def __init__(self, mn, pin=None):
+        self.mn = mn
+        self.net_name = list()
+        self.metal_seg = list()
+        self.via_list = list()
+        self.pin = pin
+        self.visited = False
+
+class netMap_vert:
+    def __init__(self):
+        self.cols = list()
+    # TODO: make them become member functions
+    def search_col(self, col_num): #cols -> self.cols
+        start=0
+        end=len(self.cols)-1
+        while start <= end:
+            mid = (start+end)//2
+            if self.cols[mid].col_num == col_num:
+                return mid
+            elif self.cols[mid].col_num > col_num:
+                end = mid-1
+            else:
+                start = mid+1
+        return None
+    
+    def search_metal_index(self, col_index, obj_y1): #col -> self.col 
+        col = self.cols[col_index]
+        start = 0
+        end = len(col.metal_list)-1
+
+        if len(col.metal_list) == 0:
+            return 0
+        
+        while start+1 < end:
+            mid = (start+end)//2
+            if col.metal_list[mid].mn[0][0] > obj_y1:       
+                end = mid
+            elif col.metal_list[mid].mn[0][0] < obj_y1:      
+                start = mid
+            else:
+                return mid+1
+
+        if col.metal_list[start].mn[0][1] > obj_y1:       
+            return start
+        elif col.metal_list[end].mn[0][1] <= obj_y1:      
+            return end+1
+        else:
+            return end
+    
+    def get_col_index(self, new_col_num):
+        start = 0
+        end = len(self.cols)-1
+        if len(self.cols) == 0:
+            return 0
+        
+        while start+1 < end:
+            mid = (start+end)//2
+            if self.cols[mid].col_num > new_col_num:
+                end = mid
+            elif self.cols[mid].col_num < new_col_num:
+                start = mid
+            else:
+                return mid
+            
+        if self.cols[start].col_num > new_col_num:
+            return start
+        elif self.cols[end].col_num < new_col_num:
+            return end+1
+        else:
+            return end
+
+    def insert_metal(self, mn, net_name=None):
+        if mn[0][0] < mn[1][0]:
+            x1=mn[0][0]
+            x2=mn[1][0]
+        else:
+            x1=mn[1][0]
+            x2=mn[0][0]
+        
+        if mn[0][1] < mn[1][1]:
+            y1=mn[0][1]
+            y2=mn[1][1]
+        else:
+            y1=mn[1][1]
+            y2=mn[0][1]
+
+
+        for i in range (x1, x2+1):
+            col_index = self.search_col(i)
+            if col_index is None:
+                #self.cols에 colNode(i)를 순서에 맞춰 삽입
+                new_col_index = self.get_col_index(i)
+                self.cols.insert(new_col_index, colNode(i))
+                new_node = metalNode([[i, y1], [i, y2]])
+                new_node.net_name.append(net_name)
+                new_node.metal_seg.append(new_node)
+                self.cols[new_col_index].metal_list.append(new_node)
+                
+            else:
+                new_node = metalNode([[i, y1], [i, y2]])
+                new_node.net_name.append(net_name)
+                new_node.metal_seg.append(new_node)
+                self.merge(new_node, col_index)
+                
+
+    def merge(self, new_metal, col_index):
+        new_metal_index = self.search_metal_index(col_index, new_metal.mn[0][1])
+
+        if new_metal_index > 0:         #row의 맨 앞이 아닌 곳에 새로운 metal을 삽입하는 경우
+            #먼저 바로 앞 metal과 겹치는지를 확인해 처리한다.=>겹치더라도 하나의 metal과만 겹침
+            if new_metal.mn[0][1]<=self.cols[col_index].metal_list[new_metal_index-1].mn[0][1]:      #앞 metal이랑 겹치면
+                metal_prev = self.cols[col_index].metal_list.pop(new_metal_index-1)
+                new_name = new_metal.net_name
+                for name in metal_prev.net_name:
+                    if name not in new_name:
+                        new_name.append(name)
+
+                new_metal.metal_seg.extend(metal_prev.metal_seg)
+
+                if new_metal.pin is None and metal_prev.pin is not None:
+                    new_pin = metal_prev.pin
+                elif new_metal.pin is not None and metal_prev.pin is None:
+                    new_pin = new_metal.pin
+                elif new_metal.pin is not None and metal_prev.pin is not None:
+                    print("Warning: pin name overlap")
+                    new_pin = new_metal.pin+'/'+metal_prev.pin
+                else:
+                    new_pin = None
+                
+                #metal_prev 끝이 newMetal 끝보다 앞에 있을 경우
+                if metal_prev.mn[1][1] < new_metal.mn[1][1]:               
+                    xy2 = new_metal.mn[1]
+                else:
+                    xy2 = metal_prev.mn[1]
+                
+                new_metal_tmp = metalNode([metal_prev.mn[0], xy2], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+                new_metal = new_metal_tmp
+                new_metal_index=new_metal_index-1
+
+        #뒤쪽 metal들과 겹치는지 확인해 처리
+        while new_metal_index<len(self.cols[col_index].metal_list):
+            if new_metal.mn[1][1]<self.cols[col_index].metal_list[new_metal_index].mn[0][1]:
+                break
+            
+            metal_next = self.cols[col_index].metal_list.pop(new_metal_index)
+            new_name = new_metal.net_name
+            for name in metal_next.net_name:
+                if name not in new_name:
+                    new_name.append(name)
+
+            new_metal.metal_seg.extend(metal_next.metal_seg)
+
+            if new_metal.pin is None and metal_next.pin is not None:
+                new_pin = metal_next.pin
+            elif new_metal.pin is not None and metal_next.pin is None:
+                new_pin = new_metal.pin
+            elif new_metal.pin is not None and metal_next.pin is not None:
+                print("Warning: pin name overlap")
+                new_pin = new_metal.pin+'/'+metal_next.pin
+            else:
+                new_pin = None
+
+            if new_metal.mn[1][1] < metal_next.mn[1][1]:          #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
+                new_metal_tmp = metalNode([new_metal.mn[0], metal_next.mn[1]], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+            else:
+                new_metal_tmp = metalNode([new_metal.mn[0], new_metal.mn[1]], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+            new_metal = new_metal_tmp
+        
+        self.cols[col_index].metal_list.insert(new_metal_index, new_metal)
+
+
+class netMap_hor:
+    def __init__(self):
+        self.rows = list()
+    
+    # TODO: make them become member functions
+    def search_row(self, row_num): #rows -> self.rows
+        start=0
+        end=len(self.rows)-1
+        while start <= end:
+            mid = (start+end)//2
+            if self.rows[mid].row_num == row_num:
+                return mid
+            elif self.rows[mid].row_num > row_num:
+                end = mid-1
+            else:
+                start = mid+1
+        return None
+    
+    def search_metal_index(self, row_index, obj_x1): #row -> self.row
+        row = self.rows[row_index]
+        start = 0
+        end = len(row.metal_list)-1
+
+        if len(row.metal_list) == 0:
+            return 0
+        
+        while start+1 < end:
+            mid = (start+end)//2
+            if row.metal_list[mid].mn[0][0] > obj_x1:       
+                end = mid
+            elif row.metal_list[mid].mn[0][0] < obj_x1:      
+                start = mid
+            else:
+                return mid+1
+
+        if row.metal_list[start].mn[0][0] > obj_x1:       
+            return start
+        elif row.metal_list[end].mn[0][0] <= obj_x1:      
+            return end+1
+        else:
+            return end
+
+    def get_row_index(self, new_row_num):
+        start = 0
+        end = len(self.rows)-1
+        if len(self.rows) == 0:
+            return 0
+        
+        while start+1 < end:
+            mid = (start+end)//2
+            if self.rows[mid].row_num > new_row_num:
+                end = mid
+            elif self.rows[mid].row_num < new_row_num:
+                start = mid
+            else:
+                return mid
+            
+        if self.rows[start].row_num > new_row_num:
+            return start
+        elif self.rows[end].row_num < new_row_num:
+            return end+1
+        else:
+            return end
+
+    def insert_metal(self, mn, net_name=None):
+        if mn[0][0] < mn[1][0]:
+            x1=mn[0][0]
+            x2=mn[1][0]
+        else:
+            x1=mn[1][0]
+            x2=mn[0][0]
+        
+        if mn[0][1] < mn[1][1]:
+            y1=mn[0][1]
+            y2=mn[1][1]
+        else:
+            y1=mn[1][1]
+            y2=mn[0][1]
+
+        for i in range (y1, y2+1):
+            row_index = self.search_row(i)
+            if row_index is None:
+                #self.rows에 rowNode(i)를 순서에 맞춰 삽입
+                new_row_index = self.get_row_index(i)
+                self.rows.insert(new_row_index, rowNode(i))
+                new_node = metalNode([[x1, i], [x2, i]])
+                new_node.net_name.append(net_name)
+                new_node.metal_seg.append(new_node)
+                self.rows[new_row_index].metal_list.append(new_node)
+            else:
+                new_node = metalNode([[x1, i], [x2, i]])
+                new_node.net_name.append(net_name)
+                new_node.metal_seg.append(new_node)
+                self.merge(new_node, row_index)
+
+    def merge(self, new_metal, row_index):
+        new_metal_index = self.search_metal_index(row_index, new_metal.mn[0][0])
+
+        if new_metal_index > 0:         #row의 맨 앞이 아닌 곳에 새로운 metal을 삽입하는 경우
+            #먼저 바로 앞 metal과 겹치는지를 확인해 처리한다.=>겹치더라도 하나의 metal과만 겹침
+            if new_metal.mn[0][0]<=self.rows[row_index].metal_list[new_metal_index-1].mn[1][0]:      #앞 metal이랑 겹치면
+                metal_prev = self.rows[row_index].metal_list.pop(new_metal_index-1)
+                new_name = new_metal.net_name
+                for name in metal_prev.net_name:
+                    if name not in new_name:
+                        new_name.append(name)
+
+                new_metal.metal_seg.extend(metal_prev.metal_seg)
+
+                if new_metal.pin is None and metal_prev.pin is not None:
+                    new_pin = metal_prev.pin
+                elif new_metal.pin is not None and metal_prev.pin is None:
+                    new_pin = new_metal.pin
+                elif new_metal.pin is not None and metal_prev.pin is not None:
+                    print("Warning: pin name overlap")
+                    new_pin = new_metal.pin+'/'+metal_prev.pin
+                else:
+                    new_pin = None
+                
+                #metal_prev 끝이 newMetal 끝보다 앞에 있을 경우
+                if metal_prev.mn[1][0] < new_metal.mn[1][0]:               
+                    xy2 = new_metal.mn[1]
+                else:
+                    xy2 = metal_prev.mn[1]
+                
+                new_metal_tmp = metalNode([metal_prev.mn[0], xy2], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+                new_metal = new_metal_tmp
+                new_metal_index=new_metal_index-1
+
+        #뒤쪽 metal들과 겹치는지 확인해 처리
+        while new_metal_index<len(self.rows[row_index].metal_list):
+            if new_metal.mn[1][0]<self.rows[row_index].metal_list[new_metal_index].mn[0][0]:
+                break
+            
+            metal_next = self.rows[row_index].metal_list.pop(new_metal_index)
+            new_name = new_metal.net_name
+            for name in metal_next.net_name:
+                if name not in new_name:
+                    new_name.append(name)
+
+            new_metal.metal_seg.extend(metal_next.metal_seg)
+
+            if new_metal.pin is None and metal_next.pin is not None:
+                new_pin = metal_next.pin
+            elif new_metal.pin is not None and metal_next.pin is None:
+                new_pin = new_metal.pin
+            elif new_metal.pin is not None and metal_next.pin is not None:
+                print("Warning: pin name overlap")
+                new_pin = new_metal.pin+'/'+metal_next.pin
+            else:
+                new_pin = None
+
+            if new_metal.mn[1][0] < metal_next.mn[1][0]:          #newMetal 끝이 뒤 metal 끝보다 앞에 있을 경우
+                new_metal_tmp = metalNode([new_metal.mn[0], metal_next.mn[1]], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+            else:
+                new_metal_tmp = metalNode([new_metal.mn[0], new_metal.mn[1]], pin=new_pin)
+                new_metal_tmp.net_name.extend(new_name)
+                new_metal_tmp.metal_seg.extend(new_metal.metal_seg)
+            new_metal = new_metal_tmp
+        
+        self.rows[row_index].metal_list.insert(new_metal_index, new_metal)
+
+
+class netMap:
+#member : type
+#layers : dict
+#layers_orient : dict
+#pins : list
+#_via_table : dict
+#grid : laygo2.object.grid
+#orient : bool
+    def __init__(self, grid, via_table:dict, orient_first="vertical",layer_names:list=['m1','m2','m3','m4','m5']):
+        self.layers=dict()
+        self.layers_orient=dict()
+        self.pins=list()
+        self._via_table=via_table
+        self.grid=grid
+        if orient_first=="vertical":
+            self.orient_order = True
+            for idx in range(len(layer_names)//2):
+                self.layers[layer_names[idx]] = netMap_vert()
+                self.layers[layer_names[idx+1]] = netMap_hor()
+                self.layers_orient[layer_names[idx]] = "vertical"
+                self.layers_orient[layer_names[idx+1]] = "horizontal"
+            if len(layer_names)%2 == 1:
+                self.layers[layer_names[-1]] = netMap_vert()
+                self.layers_orient[layer_names[-1]] = "vertical"
+
+        elif orient_first=="horizontal":
+            self.orient_order = False
+            for idx in range(len(layer_names)//2):
+                self.layers[layer_names[idx]] = netMap_hor()
+                self.layers[layer_names[idx+1]] = netMap_vert()
+                self.layers_orient[layer_names[idx]] = "horizontal"
+                self.layers_orient[layer_names[idx+1]] = "vertical"
+            if len(layer_names)%2 == 1:
+                self.layers[layer_names[-1]] = netMap_hor()
+                self.layers_orient[layer_names[-1]] = "horizontal"
+        else:
+            print("wrong orient")
+    
+    def insert_metal(self, metal):
+        pass
+    
+    def insertPin(self, pin):
+        pass
+
+    def is_via(self, _inst):
+        if _inst.cellname in self._via_table:
+            return True
+        else: 
+            return False
+
+    def insert_via(self, inst):
+        if not netMap.is_via(inst):
+            print("error:"+inst+"is not_via")
+        #via_mn, layer1(vertical), layer2(horizontal) mapping
+        via_mn = self.grid.mn(inst.xy)
+        if self.layers_orient[self._via_table[inst.cellname][0]] == "vertical":
+            layer1, layer2 = self._via_table[inst.cellname]
+        else:
+            layer2, layer1 = self._via_table[inst.cellname]
+        
+        col_index = layer1.search_col(layer1.cols, via_mn[1])
+        if col_index is None:
+            print("Error: no metal on via")
+            return
+        metal_index = layer1.search_metal_index(layer1.cols[col_index], via_mn[0])-1
+        if metal_index == -1:
+            print("Error: no metal on via")
+            return
+        layer1_metal = layer1.cols[col_index].metal_list[metal_index]
+        if layer1_metal.mn[1][1] < via_mn[1]:
+            print("Error: no metal on via")
+            return
+
+        row_index = layer2.search_row(layer2.rows, via_mn[1])
+        if row_index is None:
+            print("Error: no metal on via")
+            return
+        metal_index = layer2.search_metal_index(layer2.rows[row_index], via_mn[0])-1
+        if metal_index == -1:
+            print("Error: no metal on via")
+            return
+        layer2_metal = layer2.rows[row_index].metal_list[metal_index]
+        if layer2_metal.mn[1][0] < via_mn[0]:
+            print("Error: no metal on via")
+            return
+        
+        layer1_metal.via_list.append([layer2_metal, layer2, via_mn])
+        layer2_metal.via_list.append([layer1_metal, layer1, via_mn])
+


### PR DESCRIPTION
수정사항
0.PEP8 convention에 맞게 코드 변경

1.netMap의 segment가 될 node(현재 metalNode 객체)를 다음과 같이 변경
->net_name을 list로 변경해 node를 구성하는 각 metal의 net 이름을 저장(중복X)
->node의 양 끝 점을 기존의 xy1, xy2 2개 list로 표시했던 부분을 laygo 관습에 맞추어 mn 이중 리스트로 변경
->기존 vias 리스트에서 via 좌표를 저장하였지만 via_list 리스트에 via가 연결하는 node의 포인터를 저장하도록 변경(insert_via 함수가 via_list를 만들어준다.)
->해당 net이 pin으로 사용될 경우에 대비해 pin의 Name을 저장할 pin 변수를 만들어놓는다.
->metal 변수 추가: node를 구성하는 기본적인 조각들의 list. merge시 자동으로 갱신됨. 논의 시 rect 객체의 list로 상정하였으나, 편의상(rect객체를 따로 만들어 저장할 필요성이 떨어짐) metalNode 객체를 저장하도록 함.

2.insert_via함수 구현
->via의 위치와 via를 뚫을 두 layer를 입력받아 두 layer에서 해당 좌표에 위치하는 node들을 확인하고, 두 node 상호 간에 각자의 via_list에 추가
->merge가 모두 끝난 이후에 호출해야 한다.

3.netMap에의 입력에 두 가지 함수를 제공:insertMetal과 insertPin
insertMetal: mn, net_name(optional)을 입력받음. 직선 형태의 metal을 배치할 수 있으며, 양 끝이 mn으로 정의됨. net의 이름을 나타내는 net_name의 경우 기본값은 None
insertPin: mn, pin_name(optional), net_name(optional)을 입력받음.  직사각형 형태로 배치가 가능하며, 대각선 양 끝은 mn으로 정의된다. pin이름을 부여하고 싶을 경우 pin_name에 이름을 넣어주면 되고, net_name의 경우 insertMetal에서와 같이 net의 이름을 나타낸다. 

4.서로 다른 pin 두 개가 merge되는 경우
->warning이라고 출력하고 일단 단순히 pin1/pin2로 저장


***미구현
같은 netMap 상의 평행하게 배열된 node간에도 pointer로 가리키게 하기.

-----------------------------------------------------------------------------------------------
8/28 추가
netMap_hor서 지적사항 수정. 혹시 몰라서 우선 netmap_template와 함께 올림.
netmap_template.py 추가. TODO 요구사항 모두 수행. 기능 테스트함. insert_via 함수는 테스트해보지는 못함(inst 객체가 뭔지를 모르겠음). 내일 코드 간결성을 위해 상속을 이용해 구현하도록 추가 수정 예정.